### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is the default workflow in v0.14
 but there are other workflows available as described in
 [PLUGINS.md](/docs/PLUGINS.md#workflows).
  
-* [Parse sample entries](/docs/plugins/sn_detectContamination-kraken.pl.md) - create an input file `samples.tsv`
+* [Parse sample entries](docs/plugins/sn_parseSampleSheet.pl.md) - create an input file `samples.tsv`
 * [Read metrics](/docs/plugins/addReadMetrics.pl.md) - get raw read yields and raw read QC summary (CG-Pipeline)
 * [Assembly](/docs/plugins/assembleAll.pl.md) - assemble each genome (Shovill/skesa)
 * [MLST](/docs/plugins/sn_mlst.pl.md) - 7-gene MLST (_mlst_)


### PR DESCRIPTION

incorrect link on main README for parse sample entries #57

changed link "docs/plugins/sn_detectContamination-kraken.pl.md" to "docs/plugins/sn_parseSampleSheet.pl.md"

Issues.


**Describe the change**

In accordance with the identified issues, I have replaced the file "sn_detectContamination-kraken.pl.md" with "sn_parseSampleSheet.pl.md."

**Does it change the usage of SneakerNetPlugins.pl?**
No.

**Did you add any unit testing? Please describe**
No.

